### PR TITLE
Move the people section to a separate file and move who are we to the top of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # datavaluepeople Defining Docs
 
+We are a collection of people who collaborate to do applied machine learning, building automated
+systems, advising, and educating, to create value for businesses, organizations, and humans.
+
 ## Purpose of this repo
 
 To be the single source of information that defines how datavaluepeople operates, and enable the
@@ -8,19 +11,6 @@ partners and members to expand and progress these in an effective way.
 This repo should replace the previous iteration of our defining docs from [Google Drive][link to
 old docs].
 
-## Who are datavaluepeople
-
-We are a collection of people who collaborate to do applied machine learning, building automated
-systems, advising, and educating, to create value for businesses, organizations, and humans.
-
-We are each one of:
-- Partner: have legal ownership, long term committed to the goals and values, decide on the
-  direction, projects, and development of dvp.
-- Member: have 100% opportunity and access within dvp but require no upfront or continued
-  commitment. When they choose to make commitments they honour them. They can work on projects,
-  input to the direction and development of dvp, while slowly strengthening their
-  relationship with dvp, with the hope of the partners that they eventually will want to become a
-  partner.
 
 ## Purpose of datavaluepeople
 

--- a/people.md
+++ b/people.md
@@ -1,0 +1,10 @@
+# Who are datavaluepeople
+
+We are each one of:
+- Partner: have legal ownership, long term committed to the goals and values, decide on the
+  direction, projects, and development of dvp.
+- Member: have 100% opportunity and access within dvp but require no upfront or continued
+  commitment. When they choose to make commitments they honour them. They can work on projects,
+  input to the direction and development of dvp, while slowly strengthening their
+  relationship with dvp, with the hope of the partners that they eventually will want to become a
+  partner.


### PR DESCRIPTION

I moved the people section to a separate file. 

During the meeting, we thought about extending the people section with the process of becoming a member and growing to partner. I am not sure how much we wanted that to be defined, so I have not added it now. 