### PR TITLE
Expanded the people section

### DIFF
--- a/people.md
+++ b/people.md
@@ -12,3 +12,8 @@ We are each one of:
 There is a further category of _non-member_ or _freelancer_.
 This category applies to someone who works with dvp on a project-by-project basis,
 but has not become a member.
+
+An example _journey_ for a newcomer could be performing a well-defined task for dvp, 
+before then engaging with dvp on a longer project.
+They are subsequently invited to become a member,
+and if the relationship continues to grow may eventually become a partner.

--- a/people.md
+++ b/people.md
@@ -9,10 +9,11 @@ We are each one of:
   while slowly strengthening their relationship with dvp, with the hope of the 
   partners that they eventually will want to become a partner.
 
-There is a further category of _non-member_ or _freelancer_. This category applies to 
-someone who works with dvp on a project-by-project basis, but has not become a member.
+There is a further category of _non-member_ or similarly _freelancer_. This category 
+applies to someone who works with dvp on a project-by-project basis, but has not 
+become a member.
 
-An example _journey_ for a newcomer could be performing a well-defined task for dvp,
+An example journey for a newcomer could be performing a well-defined task for dvp, 
 before then engaging with dvp on a longer project. They are subsequently invited to 
-become a member, and if the relationship continues to grow may eventually become a 
+become a member, and if the relationship continues to grow they may eventually become a 
 partner.

--- a/people.md
+++ b/people.md
@@ -1,19 +1,18 @@
 # Who are datavaluepeople
 
 We are each one of:
-- Partner: have legal ownership, long term committed to the goals and values, decide on the
-  direction, projects, and development of dvp.
-- Member: have 100% opportunity and access within dvp but require no upfront or continued
-  commitment. When they choose to make commitments they honour them. They can work on projects and
-  provide input to the direction and development of dvp, while slowly strengthening their
-  relationship with dvp, with the hope of the partners that they eventually will want to become a
-  partner.
+- Partner: have legal ownership, long term committed to the goals and values, decide 
+  on the direction, projects, and development of dvp.
+- Member: have 100% opportunity and access within dvp but require no upfront or 
+  continued commitment. When they choose to make commitments they honour them. They 
+  can work on projects and provide input to the direction and development of dvp, 
+  while slowly strengthening their relationship with dvp, with the hope of the 
+  partners that they eventually will want to become a partner.
 
-There is a further category of _non-member_ or _freelancer_.
-This category applies to someone who works with dvp on a project-by-project basis,
-but has not become a member.
+There is a further category of _non-member_ or _freelancer_. This category applies to 
+someone who works with dvp on a project-by-project basis, but has not become a member.
 
-An example _journey_ for a newcomer could be performing a well-defined task for dvp, 
-before then engaging with dvp on a longer project.
-They are subsequently invited to become a member,
-and if the relationship continues to grow may eventually become a partner.
+An example _journey_ for a newcomer could be performing a well-defined task for dvp,
+before then engaging with dvp on a longer project. They are subsequently invited to 
+become a member, and if the relationship continues to grow may eventually become a 
+partner.

--- a/people.md
+++ b/people.md
@@ -8,3 +8,7 @@ We are each one of:
   provide input to the direction and development of dvp, while slowly strengthening their
   relationship with dvp, with the hope of the partners that they eventually will want to become a
   partner.
+
+There is a further category of _non-member_ or _freelancer_.
+This category applies to someone who works with dvp on a project-by-project basis,
+but has not become a member.

--- a/people.md
+++ b/people.md
@@ -4,7 +4,7 @@ We are each one of:
 - Partner: have legal ownership, long term committed to the goals and values, decide on the
   direction, projects, and development of dvp.
 - Member: have 100% opportunity and access within dvp but require no upfront or continued
-  commitment. When they choose to make commitments they honour them. They can work on projects,
-  input to the direction and development of dvp, while slowly strengthening their
+  commitment. When they choose to make commitments they honour them. They can work on projects and
+  provide input to the direction and development of dvp, while slowly strengthening their
   relationship with dvp, with the hope of the partners that they eventually will want to become a
   partner.


### PR DESCRIPTION
Wanted to include the category of non-member and specify an explanatory example _journey_ with dvp whilst avoiding making it sounds like a fixed process.